### PR TITLE
Fix uninitialized pointer access in HashTable default constructor

### DIFF
--- a/struktur_data/hash_table/hash_function/division_method.cpp
+++ b/struktur_data/hash_table/hash_function/division_method.cpp
@@ -33,9 +33,7 @@ private:
 
 public:
     // default constructor
-    HashTable() : m(0) {
-        table = new Node*[m];
-        table[m] = nullptr;
+    HashTable() : m(0), table(nullptr) {
     }
 
     explicit HashTable(int size) : m(size) {


### PR DESCRIPTION
The default constructor for `HashTable` was attempting to allocate an array of size 0 and then accessing `table[m]`, which is an out-of-bounds access. 

Changed the default constructor to initialize `table` to `nullptr` instead of attempting invalid memory allocation.

---

*This PR was generated by [PRJanitor](https://prjanitor.com) — an automated tool that finds and fixes small bugs in open-source projects.*

We respect your contribution guidelines — if your project doesn't accept bot PRs, we won't send more. You can also add a `.github/prjanitor.yml` file with `enabled: false` to opt out explicitly.